### PR TITLE
Ensure package.json ends with a newline character (fixes #3)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -93,7 +93,7 @@ class EhVersionerCommand extends Command {
     }
 
     if (!flags['dry-run']) {
-      fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2))
+      fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n')
       if (!flags.init) {
         try {
           commitChanges(updateList, current, bumped, flags)


### PR DESCRIPTION
We use [prettier](https://prettier.io/) on our project, and one of the things it enforces is that all files should end with a newline character.

This PR ensures that the final newline is preserved after running `eh-bumpversion`, so that our `package.json` remains properly formatted